### PR TITLE
Fix profile migration file

### DIFF
--- a/db/migrate/20190309080220_add_null_to_profiles.rb
+++ b/db/migrate/20190309080220_add_null_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddNullToProfiles < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :profiles, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190309072351) do
+ActiveRecord::Schema.define(version: 20190309080220) do
 
   create_table "areas", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "prefecture", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20190309072351) do
     t.integer  "birth_year",       null: false
     t.integer  "birth_month",      null: false
     t.integer  "birth_day",        null: false
-    t.integer  "user_id"
+    t.integer  "user_id",          null: false
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.index ["user_id"], name: "index_profiles_on_user_id", using: :btree


### PR DESCRIPTION
# WHAT
・マイグレーションファイルadd_null_to_profilesの作成
・profilesテーブルのuser_idカラムにnull制約の追加

# WHY
・null制約の記載が漏れていたため