### PR TITLE
AddNewProdoctsBrand

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,7 +19,7 @@ before_action :authenticate_user!, except: [:index, :show]
 #トップページへリダイレクト
   def create
     @product = Product.new(product_params)
-    @product.update_brand(params[:product][:brand_attributes][:name]) if params[:product][:brand_attributes][:name]
+    @product.update_brand(params[:product][:brand_attributes][:name]) if params[:product][:brand_attributes][:name].present?
     if @product.save
       redirect_to root_path
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,6 +19,7 @@ before_action :authenticate_user!, except: [:index, :show]
 #トップページへリダイレクト
   def create
     @product = Product.new(product_params)
+    @product.update_brand(params[:product][:brand_attributes][:name]) if params[:product][:brand_attributes][:name]
     if @product.save
       redirect_to root_path
     else

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,8 +3,6 @@ class Product < ApplicationRecord
   belongs_to :user
   belongs_to :area
   belongs_to :product_size
-  belongs_to :brand
-  accepts_nested_attributes_for :brand
   belongs_to :brand, optional: true
   accepts_nested_attributes_for :brand, reject_if: :reject_brand_blank
   has_many :product_images
@@ -36,4 +34,9 @@ class Product < ApplicationRecord
     empty = attributes[:name].blank?
     exists || empty
   end
+
+  def update_brand(brand_name)
+    self.brand = Brand.find_by(name: brand_name) if Brand.find_by(name: brand_name)
+  end
+
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -29,7 +29,6 @@ class Product < ApplicationRecord
   validates :user_id, presence: true
 
   def reject_brand_blank(attributes)
-    binding.pry
     exists = Brand.find_by(name: attributes[:name])
     empty = attributes[:name].blank?
     exists || empty

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,6 +5,8 @@ class Product < ApplicationRecord
   belongs_to :product_size
   belongs_to :brand
   accepts_nested_attributes_for :brand
+  belongs_to :brand, optional: true
+  accepts_nested_attributes_for :brand, reject_if: :reject_brand_blank
   has_many :product_images
   accepts_nested_attributes_for :product_images, limit: 10
   belongs_to :category
@@ -28,4 +30,10 @@ class Product < ApplicationRecord
   validates :estimated_date, presence: true
   validates :user_id, presence: true
 
+  def reject_brand_blank(attributes)
+    binding.pry
+    exists = Brand.find_by(name: attributes[:name])
+    empty = attributes[:name].blank?
+    exists || empty
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -29,7 +29,7 @@ class Product < ApplicationRecord
   validates :user_id, presence: true
 
   def reject_brand_blank(attributes)
-    exists = Brand.find_by(name: attributes[:name])
+    exists = Brand.find_by(name: attributes[:name]).present?
     empty = attributes[:name].blank?
     exists || empty
   end

--- a/db/migrate/20190313040442_remove_column_brand_to_prodoct.rb
+++ b/db/migrate/20190313040442_remove_column_brand_to_prodoct.rb
@@ -1,0 +1,7 @@
+class RemoveColumnBrandToProdoct < ActiveRecord::Migration[5.0]
+  def change
+    remove_foreign_key :products, :brands
+    remove_index :products, :brand_id
+    remove_reference :products, :brand
+  end
+end

--- a/db/migrate/20190313040911_add_columns_brand_id_to_products.rb
+++ b/db/migrate/20190313040911_add_columns_brand_id_to_products.rb
@@ -1,0 +1,5 @@
+class AddColumnsBrandIdToProducts < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :products, :brand, null:true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190313030845) do
+ActiveRecord::Schema.define(version: 20190313040911) do
 
   create_table "adresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "zip_code",   null: false
@@ -87,7 +87,6 @@ ActiveRecord::Schema.define(version: 20190313030845) do
     t.integer  "area_id",                       null: false
     t.integer  "condition",                     null: false
     t.integer  "product_size_id",               null: false
-    t.integer  "brand_id",                      null: false
     t.integer  "shipping_method",               null: false
     t.integer  "shipping_burden",               null: false
     t.integer  "estimated_date",                null: false
@@ -95,6 +94,7 @@ ActiveRecord::Schema.define(version: 20190313030845) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.integer  "category_id"
+    t.integer  "brand_id"
     t.index ["area_id"], name: "index_products_on_area_id", using: :btree
     t.index ["brand_id"], name: "index_products_on_brand_id", using: :btree
     t.index ["category_id"], name: "index_products_on_category_id", using: :btree


### PR DESCRIPTION
# WHAT
・商品登録の際に入力しようとしたブランドがすでに存在した場合、保存せずに既存のIDを代入する
・空欄の場合は保存を行わない

# WHY
・不要なレコードを増やさないため