### PR TITLE
AddS3

### DIFF
--- a/app/uploaders/product_images_uploader.rb
+++ b/app/uploaders/product_images_uploader.rb
@@ -6,8 +6,7 @@ class ProductImagesUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [220, 220]
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -43,7 +42,7 @@ class ProductImagesUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+    region: 'ap-northeast-1'
+  }
+
+  config.fog_directory  = 'freemarket-sample-45b'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket-sample-45b'
+end


### PR DESCRIPTION
# WHAT
画像のアップロード先をS３に指定

# WHY
AWSアカウントの容量を圧迫しないため