### PR TITLE
FixUploader

### DIFF
--- a/app/uploaders/product_images_uploader.rb
+++ b/app/uploaders/product_images_uploader.rb
@@ -6,7 +6,13 @@ class ProductImagesUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [220, 220]
 
   # Choose what kind of storage to use for this uploader:
-  storage :fog
+  Rails.env.development?
+   storage :file
+  elsif Rails.env.test?
+   storage :file
+  else
+   storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# WHAT
開発環境でのimageの保存先をローカルに変更

# WHY
開発環境での保存先はローカルが適切だから