### PR TITLE
add_bread-crumbs_function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem 'omniauth'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem 'mini_magick'
+gem 'gretel'
 
 group :production do
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -334,6 +336,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/views/credit_card/new.html.haml
+++ b/app/views/credit_card/new.html.haml
@@ -1,8 +1,8 @@
 = render "shared/header"
-
+- breadcrumb :new_credit_card
 .mypage
   %nav.bread-crumbs
-
+    = breadcrumbs separator: " > "
   %main.mypage__body.clearfix
     .mypage__body__main
       %section.creditcard-form

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -1,9 +1,9 @@
 .wrapper
   %header.pc-header
     = render 'shared/header'
-
+  - breadcrumb :new_profile
   %nav.bread-crumbs
-
+    = breadcrumbs separator: " > "
   %main.l-container.clearfix
     .l-content
       %section.l-chapter-container.mypage-identification

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,7 +1,7 @@
 = render "shared/header"
-
+- breadcrumb :edit_user
 %nav.bread-crumbs
-
+  = breadcrumbs separator: " > "
 .mypage
   %main.mypage__body.clearfix
     .mypage__body__main

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 = render "shared/header"
-
+- breadcrumb :users
 %nav.bread-crumbs
-
+  = breadcrumbs separator: " > "
 .mypage
   %main.mypage__body.clearfix
 

--- a/app/views/users/signout.html.haml
+++ b/app/views/users/signout.html.haml
@@ -1,9 +1,9 @@
 = render 'shared/header'
-
+- breadcrumb :signout_users
 .mypage
 
   %nav.bread-crumbs
-
+    = breadcrumbs separator: " > "
   %main.mypage__body.clearfix
 
     .mypage__body__main

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,33 @@
+crumb :root do
+  link "メルカリ🍜", root_path
+end
+
+# users#show
+crumb :users do
+  link "マイページ", user_path(current_user.id)
+  parent :root
+end
+
+# users#edit
+crumb :edit_user do
+  link "プロフィール", edit_user_path
+  parent :users
+end
+
+# users#signout
+crumb :signout_users do
+  link "ログアウト",signout_users_path
+  parent :users
+end
+
+# credit_card#new
+crumb :new_credit_card do
+  link "支払い方法", new_user_credit_card_path
+  parent :users
+end
+
+# profiles#new
+crumb :new_profile do
+  link "本人情報の登録", new_user_profile_path
+  parent :users
+end


### PR DESCRIPTION
WHAT
・マイページ関連のパンくずリストの実装
・パンくず用gem「gretel」導入
・パンくずリスト表示元データとなるbreadcrumbs.rbの作成、記述
・パンくずリストが表示されるよう各種ビューにコード追記
・それに伴いcss整える
参考URL: https://www.virment.com/rails_gretel_for_breadcrumb/

WHY
・必須機能のため