### PR TITLE
fix_social-login-function

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -23,7 +23,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       session[:password] = @user.password
       session[:provider] = @user.provider
       session[:uid] = @user.uid
-      redirect_to new_user_registration_sns_path
+      redirect_to new_user_registration_path
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   before_action :set_user, only: [:edit, :update]
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :new
   def new
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,18 +17,12 @@ class User < ApplicationRecord
         uid:      auth.uid,
         provider: auth.provider,
         nickname:     auth.info.name,
-        email:    User.dummy_email(auth),
+        email:    auth.info.email,
         password: Devise.friendly_token[0, 20]
       )
     end
 
     user
-  end
-
-  private
-
-  def self.dummy_email(auth)
-    "#{auth.uid}-#{auth.provider}@example.com"
   end
 
 end


### PR DESCRIPTION
# What
・ソーシャルログイン時にemailをダミーアドレスにしてたのを、ソーシャルアカウントのメアドで登録されるよう修正。
・ついでにusers/newページのbefore_action :authenticate_user!を解除
# Why
・本来のソーシャルログイン機能としてメアドがダミーなのはよろしくないので
# 備考
・Facebookでのログイン時は、相変わらずローカル環境のみでしか機能しません。
・facebookのアプリ管理者ページで許可しているテスト用アカウントのみ機能します。
テスト用アカウントは
Email:
tesuto_bsfbjcn_tesuto@tfbnw.net
Pass:
mercari
